### PR TITLE
Fix URL creation.

### DIFF
--- a/sdk/YDSession.m
+++ b/sdk/YDSession.m
@@ -567,9 +567,8 @@
 
 + (NSURL *)urlForDiskPath:(NSString *)uri
 {
-    uri = [@"https://webdav.yandex.ru" stringByAppendingFormat:([uri hasPrefix:@"/"]?@"%@":@"/%@"), uri];
     uri = [uri stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLPathAllowedCharacterSet];
-
+    uri = [@"https://webdav.yandex.ru" stringByAppendingFormat:([uri hasPrefix:@"/"]?@"%@":@"/%@"), uri];
     return [NSURL URLWithString:uri];
 }
 


### PR DESCRIPTION
The previous PR broke Yandex.Disk upload. `urlForDiskPath` was creating wrong URL like this one:  `https%3A//webdav.yandex.ru/`.

Before:
![screen shot 2016-10-17 at 14 17 09](https://cloud.githubusercontent.com/assets/239692/19437204/a59c334e-9474-11e6-8b7c-375980359f19.png)

After:
![screen shot 2016-10-17 at 14 16 18](https://cloud.githubusercontent.com/assets/239692/19437205/a59fe98a-9474-11e6-8861-4277ee1c9c58.png)
